### PR TITLE
Alpha channel handling in CLI

### DIFF
--- a/cmdapp/Cargo.toml
+++ b/cmdapp/Cargo.toml
@@ -13,4 +13,5 @@ keywords = ["svg", "computer-graphics"]
 [dependencies]
 clap = "2.33.3"
 image = "0.23.10"
-visioncortex = "0.6.0"
+visioncortex = "0.7.0"
+rand = "0.8"

--- a/cmdapp/Cargo.toml
+++ b/cmdapp/Cargo.toml
@@ -13,5 +13,5 @@ keywords = ["svg", "computer-graphics"]
 [dependencies]
 clap = "2.33.3"
 image = "0.23.10"
-visioncortex = "0.7.0"
+visioncortex = { version = "0.7.0", git = "https://github.com/visioncortex/visioncortex" }
 rand = "0.8"

--- a/cmdapp/Cargo.toml
+++ b/cmdapp/Cargo.toml
@@ -14,4 +14,4 @@ keywords = ["svg", "computer-graphics"]
 clap = "2.33.3"
 image = "0.23.10"
 visioncortex = { version = "0.7.0", git = "https://github.com/visioncortex/visioncortex" }
-rand = "0.8"
+fastrand = "1.8"

--- a/cmdapp/src/converter.rs
+++ b/cmdapp/src/converter.rs
@@ -59,12 +59,11 @@ fn find_unused_color_in_image(img: &ColorImage) -> Result<Color, String> {
 }
 
 fn should_key_image(img: &ColorImage) -> bool {
-    // Avoid potential integer underflow
-    if img.height == 0 {
+    if img.width == 0 || img.height == 0 {
         return false;
     }
 
-    // Check boundary pixels (top and bottom rows) for transparency.
+    // Check for transparency in top and bottom rows of pixels
     let threshold = ((img.width * 2) as f32 * KEYING_THRESHOLD) as usize;
     let mut num_transparent_boundary_pixels = 0;
     for x in 0..img.width {
@@ -77,6 +76,17 @@ fn should_key_image(img: &ColorImage) -> bool {
 
         if num_transparent_boundary_pixels >= threshold {
             return true;
+        }
+    }
+
+    // Check for transparency in some inner pixels
+    let x_positions = [img.width / 4, img.width / 2, 3 * img.width / 4];
+    let y_positions = [img.height / 4, img.height / 2, 3 * img.height / 4];
+    for x in x_positions {
+        for y in y_positions {
+            if img.get_pixel(x, y).a == 0 {
+                return true;
+            }
         }
     }
 

--- a/cmdapp/src/converter.rs
+++ b/cmdapp/src/converter.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 use std::{fs::File, io::Write};
 
+use fastrand::Rng;
 use visioncortex::{Color, ColorImage, ColorName};
 use visioncortex::color_clusters::{Runner, RunnerConfig, KeyingAction, HIERARCHICAL_MAX};
 use super::config::{Config, ColorMode, Hierarchical, ConverterConfig};
@@ -35,11 +36,12 @@ fn find_unused_color_in_image(img: &ColorImage) -> Result<Color, String> {
         Color::new(0, 255, 0),
         Color::new(0, 0, 255)
     ]);
+    let rng = Rng::new();
     let random_colors = (0..NUM_UNUSED_COLOR_ITERATIONS).map(|_| {
         Color::new(
-            rand::random(),
-            rand::random(),
-            rand::random(),
+            rng.u8(..),
+            rng.u8(..),
+            rng.u8(..),
         )
     });
     for color in special_colors.chain(random_colors) {

--- a/cmdapp/src/converter.rs
+++ b/cmdapp/src/converter.rs
@@ -117,18 +117,16 @@ fn color_image_to_svg(config: ConverterConfig) -> Result<(), String> {
     let mut svg = SvgFile::new(width, height, config.path_precision);
     for &cluster_index in view.clusters_output.iter().rev() {
         let cluster = view.get_cluster(cluster_index);
-        if cluster.color() != key_color {
-            let paths = cluster.to_compound_path(
-                &view,
-                false,
-                config.mode,
-                config.corner_threshold,
-                config.length_threshold,
-                config.max_iterations,
-                config.splice_threshold
-            );
-            svg.add_path(paths, cluster.residue_color());
-        }
+        let paths = cluster.to_compound_path(
+            &view,
+            false,
+            config.mode,
+            config.corner_threshold,
+            config.length_threshold,
+            config.max_iterations,
+            config.splice_threshold
+        );
+        svg.add_path(paths, cluster.residue_color());
     }
 
     write_svg(svg, config.output_path)

--- a/cmdapp/src/converter.rs
+++ b/cmdapp/src/converter.rs
@@ -35,9 +35,12 @@ fn color_exists_in_image(img: &ColorImage, color: Color) -> bool {
 
 fn find_unused_color_in_image(img: &ColorImage) -> Result<Color, String> {
     let special_colors = IntoIterator::into_iter([
-        Color::new(255, 0, 0),
-        Color::new(0, 255, 0),
-        Color::new(0, 0, 255)
+        Color::new(255, 0,   0),
+        Color::new(0,   255, 0),
+        Color::new(0,   0,   255),
+        Color::new(255, 255, 0),
+        Color::new(0,   255, 255),
+        Color::new(255, 0,   255),
     ]);
     let rng = Rng::new();
     let random_colors = (0..NUM_UNUSED_COLOR_ITERATIONS).map(|_| {

--- a/cmdapp/src/converter.rs
+++ b/cmdapp/src/converter.rs
@@ -7,7 +7,7 @@ use visioncortex::color_clusters::{Runner, RunnerConfig, KeyingAction, HIERARCHI
 use super::config::{Config, ColorMode, Hierarchical, ConverterConfig};
 use super::svg::SvgFile;
 
-const NUM_UNUSED_COLOR_ITERATIONS: usize = 300;
+const NUM_UNUSED_COLOR_ITERATIONS: usize = 6;
 
 /// Convert an image file into svg file
 pub fn convert_image_to_svg(config: Config) -> Result<(), String> {


### PR DESCRIPTION
This depends on [my PR on visualcortex](https://github.com/visioncortex/visioncortex/pull/6). My approach is first to find a solid color that does not appear anywhere in the input image. Then, I replace all perfectly-transparent pixels with that solid color. Then, I pass the appropriate `KeyingAction` value to effectively ignore all keyed pixels.