### PR TITLE
Python Bindings. Again. No, really!

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -16,28 +16,28 @@ permissions:
   contents: read
 
 jobs:
-  # linux:
-  #   runs-on: ubuntu-latest
-  #   strategy:
-  #     matrix:
-  #       target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-python@v4
-  #       with:
-  #         python-version: '3.10'
-  #     - name: Build wheels
-  #       uses: PyO3/maturin-action@v1
-  #       with:
-  #         target: ${{ matrix.target }}
-  #         args: -m cmdapp/Cargo.toml --release --features=python-binding --out dist --find-interpreter
-  #         sccache: 'true'
-  #         manylinux: auto
-  #     - name: Upload wheels
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: wheels
-  #         path: dist
+  linux:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target: [x86_64, x86, aarch64, armv7, s390x, ppc64le]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.target }}
+          args: -m cmdapp/Cargo.toml --release --out dist --find-interpreter
+          sccache: 'true'
+          manylinux: auto
+      - name: Upload wheels
+        uses: actions/upload-artifact@v3
+        with:
+          name: wheels
+          path: dist
 
   windows:
     runs-on: windows-latest
@@ -54,7 +54,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: -m cmdapp/Cargo.toml --release --features=python-binding --out dist --find-interpreter
+          args: -m cmdapp/Cargo.toml --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3
@@ -76,7 +76,7 @@ jobs:
         uses: PyO3/maturin-action@v1
         with:
           target: ${{ matrix.target }}
-          args: -m cmdapp/Cargo.toml --release --features=python-binding --out dist --find-interpreter
+          args: -m cmdapp/Cargo.toml --release --out dist --find-interpreter
           sccache: 'true'
       - name: Upload wheels
         uses: actions/upload-artifact@v3

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -108,7 +108,7 @@ jobs:
       # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     if: "startsWith(github.ref, 'refs/tags/')"
-    needs: [windows, macos, sdist] # linux
+    needs: [windows, macos, sdist, linux] 
     steps:
       - uses: actions/download-artifact@v3
         with:

--- a/cmdapp/Cargo.toml
+++ b/cmdapp/Cargo.toml
@@ -19,3 +19,7 @@ pyo3 = { version = "0.19.0", optional = true }
 
 [features]
 python-binding = ["pyo3"]
+
+[lib]
+name = "vtracer"
+crate-type = ["cdylib"]

--- a/cmdapp/pyproject.toml
+++ b/cmdapp/pyproject.toml
@@ -23,6 +23,6 @@ requires = ["maturin>=1.2,<2.0"]
 build-backend = "maturin"
 
 [tool.maturin]
-features = ["pyo3/extension-module"]
+features = ["pyo3/extension-module", "python-binding"]
 compatibility = "manylinux2014"
 sdist-include = ["LICENSE-MIT", "vtracer/README.md"]

--- a/cmdapp/src/main.rs
+++ b/cmdapp/src/main.rs
@@ -1,8 +1,10 @@
-use vtracer::{Config, convert_image_to_svg};
+mod config;
+mod converter;
+mod svg;
 
 fn main() {
-    let config = Config::from_args();
-    let result = convert_image_to_svg(config);
+    let config = config::Config::from_args();
+    let result = converter::convert_image_to_svg(config);
     match result {
         Ok(()) => {
             println!("Conversion successful.");


### PR DESCRIPTION
- previously we had an issue where binaries were included in the built python wheel packages. Fixed this by making an explicit `[lib]` section in the Cargo.toml with `crate-type = ["cdylib"]`
- linux build & publish are re-enabled in the python.yml file
- Had to make some explicit imports in `main.rs`; adding an explicit `[lib]` caused the build to fail otherwise.

I believe PyPI publish should just work, but you'll have to try that out. The [build](https://github.com/etjones/vtracer/actions/runs/6238606336) worked for all platforms, and the wheels generated contain the correct dynamic library files.