### PR TITLE
Add support for conversion from python bytes

### DIFF
--- a/cmdapp/src/python.rs
+++ b/cmdapp/src/python.rs
@@ -44,9 +44,9 @@ fn convert_image_to_svg_py(
 }
 
 #[pyfunction]
-fn convert_py(
+fn convert_raw_image_to_svg(
     img_bytes: Vec<u8>,
-    img_format: Option<&str>,      // Format of the image. If not provided, the image format will be guessed based on its contents. 
+    img_format: Option<&str>,      // Format of the image (e.g. 'jpg', 'png'... A full list of supported formats can be found [here](https://docs.rs/image/latest/image/enum.ImageFormat.html)). If not provided, the image format will be guessed based on its contents. 
     colormode: Option<&str>,       // "color" or "binary"
     hierarchical: Option<&str>,    // "stacked" or "cutout"
     mode: Option<&str>,            // "polygon", "spline", "none"
@@ -161,6 +161,6 @@ fn construct_config(
 #[pymodule]
 fn vtracer(_py: Python, m: &PyModule) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(convert_image_to_svg_py, m)?)?;
-    m.add_function(wrap_pyfunction!(convert_py, m)?)?;
+    m.add_function(wrap_pyfunction!(convert_raw_image_to_svg, m)?)?;
     Ok(())
 }

--- a/cmdapp/vtracer/README.md
+++ b/cmdapp/vtracer/README.md
@@ -54,7 +54,7 @@ vtracer.convert_image_to_svg_py(inp, out, colormode='binary')
 
 # Convert from raw image bytes
 input_img_bytes: bytes = get_bytes() # e.g. reading bytes from a file or a HTTP request body
-svg_str: str = vtracer.convert_raw_image_to_svg(f.read(), img_format = 'jpg')
+svg_str: str = vtracer.convert_raw_image_to_svg(input_img_bytes, img_format = 'jpg')
 
 # Convert from RGBA image pixels
 from PIL import Image

--- a/cmdapp/vtracer/README.md
+++ b/cmdapp/vtracer/README.md
@@ -52,7 +52,17 @@ vtracer.convert_image_to_svg_py(inp, out)
 # Single-color example. Good for line art, and much faster than full color:
 vtracer.convert_image_to_svg_py(inp, out, colormode='binary')
 
-# All the bells & whistles
+# Convert from raw image bytes
+input_img_bytes: bytes = get_bytes() # e.g. reading bytes from a file or a HTTP request body
+svg_str: str = vtracer.convert_raw_image_to_svg(f.read(), img_format = 'jpg')
+
+# Convert from RGBA image pixels
+from PIL import Image
+img = Image.open(input_path).convert('RGBA')
+pixels: list[tuple[int, int, int, int]] = list(img.getdata())
+svg_str: str = vtracer.convert_pixels_to_svg(pixels)
+
+# All the bells & whistles, also applicable to convert_raw_image_to_svg and convert_pixels_to_svg. 
 vtracer.convert_image_to_svg_py(inp,
                                 out,
                                 colormode = 'color',        # ["color"] or "binary"

--- a/cmdapp/vtracer/__init__.py
+++ b/cmdapp/vtracer/__init__.py
@@ -1,1 +1,2 @@
-from .vtracer import convert_image_to_svg_py, convert_raw_image_to_svg
+from .vtracer import (convert_image_to_svg_py, convert_pixels_to_svg,
+                      convert_raw_image_to_svg)

--- a/cmdapp/vtracer/__init__.py
+++ b/cmdapp/vtracer/__init__.py
@@ -1,1 +1,1 @@
-from .vtracer import convert_image_to_svg_py
+from .vtracer import convert_image_to_svg_py, convert_py

--- a/cmdapp/vtracer/__init__.py
+++ b/cmdapp/vtracer/__init__.py
@@ -1,1 +1,1 @@
-from .vtracer import convert_image_to_svg_py, convert_py
+from .vtracer import convert_image_to_svg_py, convert_raw_image_to_svg

--- a/cmdapp/vtracer/vtracer.pyi
+++ b/cmdapp/vtracer/vtracer.pyi
@@ -31,3 +31,19 @@ def convert_raw_image_to_svg(img_bytes: bytes,
                             path_precision: Optional[int] = None,   # default: 8
                         ) -> str:
     ...
+
+def convert_pixels_to_svg(rgba_pixels: list[tuple[int, int, int, int]],
+                            size: tuple[int, int],
+                            colormode: Optional[str] = None,        # ["color"] or "binary"
+                            hierarchical: Optional[str] = None,     # ["stacked"] or "cutout"
+                            mode: Optional[str] = None,             # ["spline"], "polygon", "none"
+                            filter_speckle: Optional[int] = None,   # default: 4
+                            color_precision: Optional[int] = None,  # default: 6
+                            layer_difference: Optional[int] = None, # default: 16
+                            corner_threshold: Optional[int] = None, # default: 60   
+                            length_threshold: Optional[float] = None, # in [3.5, 10] default: 4.0
+                            max_iterations: Optional[int] = None,   # default: 10
+                            splice_threshold: Optional[int] = None, # default: 45
+                            path_precision: Optional[int] = None,   # default: 8
+                        ) -> str:
+    ...

--- a/cmdapp/vtracer/vtracer.pyi
+++ b/cmdapp/vtracer/vtracer.pyi
@@ -16,9 +16,8 @@ def convert_image_to_svg_py(image_path: str,
                         ) -> None:
     ...
 
-def convert_py(
-                            img_bytes: bytes,
-                            img_format: Optional[str] = None,       # Format of the image. If not provided, the image format will be guessed based on its contents. 
+def convert_raw_image_to_svg(img_bytes: bytes,
+                            img_format: Optional[str] = None,       # Format of the image (e.g. 'jpg', 'png'... A full list of supported formats can be found [here](https://docs.rs/image/latest/image/enum.ImageFormat.html)). If not provided, the image format will be guessed based on its contents. 
                             colormode: Optional[str] = None,        # ["color"] or "binary"
                             hierarchical: Optional[str] = None,     # ["stacked"] or "cutout"
                             mode: Optional[str] = None,             # ["spline"], "polygon", "none"

--- a/cmdapp/vtracer/vtracer.pyi
+++ b/cmdapp/vtracer/vtracer.pyi
@@ -15,3 +15,20 @@ def convert_image_to_svg_py(image_path: str,
                             path_precision: Optional[int] = None,   # default: 8
                         ) -> None:
     ...
+
+def convert_py(
+                            img_bytes: bytes,
+                            img_format: Optional[str] = None,       # Format of the image. If not provided, the image format will be guessed based on its contents. 
+                            colormode: Optional[str] = None,        # ["color"] or "binary"
+                            hierarchical: Optional[str] = None,     # ["stacked"] or "cutout"
+                            mode: Optional[str] = None,             # ["spline"], "polygon", "none"
+                            filter_speckle: Optional[int] = None,   # default: 4
+                            color_precision: Optional[int] = None,  # default: 6
+                            layer_difference: Optional[int] = None, # default: 16
+                            corner_threshold: Optional[int] = None, # default: 60   
+                            length_threshold: Optional[float] = None, # in [3.5, 10] default: 4.0
+                            max_iterations: Optional[int] = None,   # default: 10
+                            splice_threshold: Optional[int] = None, # default: 45
+                            path_precision: Optional[int] = None,   # default: 8
+                        ) -> str:
+    ...


### PR DESCRIPTION
This PR changes only the python binding of the library. 

A new python function `convert_py` is exposed to allow conversion from image bytes into a SVG string, without needing to interact with the file system. Doing so addresses [discussion #73 ](https://github.com/visioncortex/vtracer/discussions/73). 

This is not a breaking change, it did not change behaviour of already exposed functions. 

There are no dependency changes involved. 