### PR TITLE
Add max-width:500px to #drop to enhance user experience

### DIFF
--- a/webapp/app/index.html
+++ b/webapp/app/index.html
@@ -18,6 +18,9 @@
             border: 1px solid #aaa;
             padding: 4px 8px;
         }
+        #drop {
+            max-width: 500px;
+        }
         #droptext {
             border: 2px dashed #000;
         }


### PR DESCRIPTION
This makes the canvas max width be 500px and so working with configuring your output feels nicer (try it out and if this is nicer I think it would be a nice addition).