### PR TITLE
fix: match filter speckle max in cmd app to web app

### DIFF
--- a/cmdapp/src/main.rs
+++ b/cmdapp/src/main.rs
@@ -172,8 +172,8 @@ pub fn config_from_args() -> (PathBuf, PathBuf, Config) {
         if value.trim().parse::<usize>().is_ok() {
             // is numeric
             let value = value.trim().parse::<usize>().unwrap();
-            if value > 16 {
-                panic!("Out of Range Error: Filter speckle is invalid at {}. It must be within [0,16].", value);
+            if value > 128 {
+                panic!("Out of Range Error: Filter speckle is invalid at {}. It must be within [0,128].", value);
             }
             config.filter_speckle = value;
         } else {


### PR DESCRIPTION
The filter speckle max in the command app doesn't match web app. This was discussed [here](https://github.com/visioncortex/vtracer/discussions/105).

I made a quick change, experimented with some images the resulting SVGs seemed to match what I was getting with the web app.