### PR TITLE
Bump pyo3 to 0.26 to fix segfaults on CPython 3.14

### DIFF
--- a/cmdapp/Cargo.toml
+++ b/cmdapp/Cargo.toml
@@ -15,7 +15,7 @@ clap = "2.33.3"
 image = "0.23.10"
 visioncortex = { version = "0.8.8" }
 fastrand = { version = "2.3" }
-pyo3 = { version = "0.19.0", optional = true }
+pyo3 = { version = "0.26", optional = true }
 
 [features]
 python-binding = ["pyo3"]

--- a/cmdapp/src/python.rs
+++ b/cmdapp/src/python.rs
@@ -7,6 +7,7 @@ use visioncortex::PathSimplifyMode;
 
 /// Python binding
 #[pyfunction]
+#[pyo3(signature = (image_path, out_path, colormode=None, hierarchical=None, mode=None, filter_speckle=None, color_precision=None, layer_difference=None, corner_threshold=None, length_threshold=None, max_iterations=None, splice_threshold=None, path_precision=None))]
 fn convert_image_to_svg_py(
     image_path: &str,
     out_path: &str,
@@ -44,6 +45,7 @@ fn convert_image_to_svg_py(
 }
 
 #[pyfunction]
+#[pyo3(signature = (img_bytes, img_format=None, colormode=None, hierarchical=None, mode=None, filter_speckle=None, color_precision=None, layer_difference=None, corner_threshold=None, length_threshold=None, max_iterations=None, splice_threshold=None, path_precision=None))]
 fn convert_raw_image_to_svg(
     img_bytes: Vec<u8>,
     img_format: Option<&str>, // Format of the image (e.g. 'jpg', 'png'... A full list of supported formats can be found [here](https://docs.rs/image/latest/image/enum.ImageFormat.html)). If not provided, the image format will be guessed based on its contents.
@@ -100,6 +102,7 @@ fn convert_raw_image_to_svg(
 }
 
 #[pyfunction]
+#[pyo3(signature = (rgba_pixels, size, colormode=None, hierarchical=None, mode=None, filter_speckle=None, color_precision=None, layer_difference=None, corner_threshold=None, length_threshold=None, max_iterations=None, splice_threshold=None, path_precision=None))]
 fn convert_pixels_to_svg(
     rgba_pixels: Vec<(u8, u8, u8, u8)>,
     size: (usize, usize),
@@ -214,7 +217,7 @@ fn construct_config(
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn vtracer(_py: Python, m: &PyModule) -> PyResult<()> {
+fn vtracer(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(convert_image_to_svg_py, m)?)?;
     m.add_function(wrap_pyfunction!(convert_raw_image_to_svg, m)?)?;
     m.add_function(wrap_pyfunction!(convert_pixels_to_svg, m)?)?;


### PR DESCRIPTION
## Problem

Every published `cp314` wheel of `vtracer` segfaults on **any** call into the extension on CPython 3.14 — e.g.:

```python
import vtracer
vtracer.convert_image_to_svg_py(image_path="any.png", out_path="out.svg")
# Segmentation fault (no Python traceback)
```

Reproduced on Linux x86_64 with CPython 3.14.5 against both `vtracer==0.6.12` and `vtracer==0.6.15`, with inputs as small as a 200x200 two-color PNG. `faulthandler` shows the crash inside `vtracer.cpython-314-*.so` immediately at the call boundary. The same code works fine on CPython <= 3.13.

## Root cause

`cmdapp/Cargo.toml` pins `pyo3 = "0.19.0"`, which predates CPython 3.14 support (pyo3 gained it in 0.26). The cp314 wheels on PyPI can therefore only have been produced through pyo3's version-forward-compatibility mode, which is not ABI-safe on 3.14 — hence the immediate native crash.

## Fix

- Bump `pyo3` to `0.26`. Per the [pyo3 0.26 README](https://github.com/PyO3/pyo3/blob/v0.26.0/README.md) it supports CPython 3.7+, so the supported-version floor does not change (MSRV 1.74).
- Add the `#[pyo3(signature = (...))]` attributes that newer pyo3 requires for trailing `Option` arguments — the Python-visible API (all keyword args optional, same defaults) is preserved exactly.
- Port the `#[pymodule]` entry point to the `Bound` API.

No workflow changes needed: `maturin --find-interpreter` picks up 3.14 as before, now against a pyo3 that actually supports it.

## Verification

Built wheels from this branch for CPython 3.12 and 3.14 (`maturin build --release --manifest-path cmdapp/Cargo.toml`):

- cp314: no segfault; traces a 1120x896 RGBA photo-like image in ~1.2 s
- cp312 vs cp314: byte-identical SVG output for the same input (710,470 bytes)
- `Option`-argument handling verified: calls with and without the optional kwargs behave as on 0.19
